### PR TITLE
Solve error network_printer

### DIFF
--- a/lib/src/network_printer.dart
+++ b/lib/src/network_printer.dart
@@ -159,7 +159,7 @@ class NetworkPrinter {
   void qrcode(
     String text, {
     PosAlign align = PosAlign.center,
-    QRSize size = QRSize.Size4,
+    QRSize size = QRSize.size4,
     QRCorrection cor = QRCorrection.L,
   }) {
     _socket.add(_generator.qrcode(text, align: align, size: size, cor: cor));


### PR DESCRIPTION
/app/.pub-cache/hosted/pub.dev/esc_pos_printer_plus-0.0.3/lib/src/network_printer.dart:162:26: Error: Member not found: 'Size4'.
    QRSize size = QRSize.Size4,
                         ^^^^^